### PR TITLE
Store Travis token in Google Key Management Service (KMS)

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ isort = "*"
 [packages]
 flask = "*"
 google-cloud-iam = "*"
+google-cloud-kms = "*"
 requests = "*"
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1967fedcd4cdf7b4d746723837ab507803727a68349f324df70789631d6f3bad"
+            "sha256": "72c35cd2bbee3a0af760302994cc7e666185953da01ff09468b7fdf20102ff93"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -46,11 +46,11 @@
         },
         "flask": {
             "hashes": [
-                "sha256:ad7c6d841e64296b962296c2c2dabc6543752985727af86a975072dea984b6f3",
-                "sha256:e7d32475d1de5facaa55e3958bc4ec66d3762076b074296aa50ef8fdc5b9df61"
+                "sha256:13f9f196f330c7c2c5d7a5cf91af894110ca0215ac051b5844701f2bfd934d52",
+                "sha256:45eb5a6fd193d6cf7e0cf5d8a5b31f83d5faae0293695626f539a823e93b13f6"
             ],
             "index": "pypi",
-            "version": "==1.0.3"
+            "version": "==1.1.1"
         },
         "google-api-core": {
             "extras": [
@@ -77,11 +77,28 @@
             "index": "pypi",
             "version": "==0.1.0"
         },
+        "google-cloud-kms": {
+            "hashes": [
+                "sha256:556ec619dda81aa4864833cfa15222f9fe3d6095b1eeccda9e2349c97549f67a",
+                "sha256:79476d31d82afbc33c1b82ce4e6e69e6557271b13a666095374ab94e7c27c5aa"
+            ],
+            "index": "pypi",
+            "version": "==1.1.0"
+        },
         "googleapis-common-protos": {
+            "extras": [
+                "grpc"
+            ],
             "hashes": [
                 "sha256:e61b8ed5e36b976b487c6e7b15f31bb10c7a0ca7bd5c0e837f4afab64b53a0c6"
             ],
             "version": "==1.6.0"
+        },
+        "grpc-google-iam-v1": {
+            "hashes": [
+                "sha256:5009e831dcec22f3ff00e89405249d6a838d1449a46ac8224907aa5b0e0b1aec"
+            ],
+            "version": "==0.11.4"
         },
         "grpcio": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -21,11 +21,14 @@ $ pipenv install --dev
 
 ### To run
 
+You must first be logged in through the `gcloud` CLI to an account with the appropriate permissions.
+
 First:
 
 ```bash
 $ export FLASK_APP=src/server.py
 $ export FLASK_ENV=development
+$ export TRAVIS_TOKEN_ENCRYPTED='CiQABCLzEBhEt1AZ3jhRvQZ2NA1ulmF76mCSwOacYSotbd6P8oASPwDsoWgyqy0ByNPQt6CM9cOpzeBEOTrCfrVKYvl63HVF7sFNUOQCnNpj6ph0P3FBnGeJ2EiwqogB9jerU/FMFA=='
 $ pipenv shell
 ```
 

--- a/app.yaml
+++ b/app.yaml
@@ -1,3 +1,6 @@
 # See https://cloud.google.com/appengine/docs/standard/python3/config/appref for all options.
 
 runtime: python37
+
+env_variables:
+  TRAVIS_TOKEN_ENCRYPTED: CiQABCLzEBhEt1AZ3jhRvQZ2NA1ulmF76mCSwOacYSotbd6P8oASPwDsoWgyqy0ByNPQt6CM9cOpzeBEOTrCfrVKYvl63HVF7sFNUOQCnNpj6ph0P3FBnGeJ2EiwqogB9jerU/FMFA==

--- a/mypy.ini
+++ b/mypy.ini
@@ -38,3 +38,6 @@ show_traceback = True
 ignore_missing_imports = False
 follow_imports = normal
 follow_imports_for_stubs = False
+
+[mypy-google.cloud]
+ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,11 +3,13 @@ cachetools==3.1.1
 certifi==2019.6.16
 chardet==3.0.4
 click==7.0
-flask==1.0.3
+flask==1.1.1
 google-api-core[grpc]==1.13.0
 google-auth==1.6.3
 google-cloud-iam==0.1.0
-googleapis-common-protos==1.6.0
+google-cloud-kms==1.1.0
+googleapis-common-protos[grpc]==1.6.0
+grpc-google-iam-v1==0.11.4
 grpcio==1.22.0
 idna==2.8
 itsdangerous==1.1.0

--- a/src/server.py
+++ b/src/server.py
@@ -1,15 +1,10 @@
 from __future__ import annotations
 
-import os
-from datetime import datetime
-
 import flask
-import requests
+
+from src.travis import TravisJob
 
 # from google.cloud import iam_credentials_v1
-
-date_mechanism_first_enabled = datetime(year=2019, month=7, day=3)
-pantsbuild_pants_travis_repo_id = 402860
 
 rbe_execute_tests_scope = [
     "remotebuildexecution.actions.create",
@@ -40,30 +35,12 @@ def index() -> str:
 
 @app.route("/token/generate", methods=["POST"])
 def generate_token() -> str:
-    travis_job_id = int(flask.request.get_json()["travis_job_id"])
-    if not is_valid_travis_job(travis_job_id):
+    travis_job = TravisJob.get_from_api(job_id=int(flask.request.get_json()["travis_job_id"]))
+    if travis_job is None:
+        flask.abort(500)
+    if not travis_job.is_valid():
         flask.abort(404)
-    return str(travis_job_id)
+    return str(travis_job)
     # return credentials_client.generate_access_token(
     #     name=service_account_path, scope=rbe_execute_tests_scope
     # ).access_token
-
-
-def is_valid_travis_job(job_id: TravisJobId) -> bool:
-    """Check that the job belongs to pantsbuild.pants and that it was created after we turned
-    on this mechanism."""
-    travis_response = requests.get(
-        f"https://api.travis-ci.org/job/{job_id}",
-        headers={"Travis-API-Version": "3", "Authorization": f"token {os.getenv('TRAVIS_TOKEN')}"},
-    )
-    data = travis_response.json()
-    try:
-        repo_id = data["repository"]["id"]
-        created_at = datetime.fromisoformat(data["created_at"][:-5])
-    except KeyError:
-        return False
-    else:
-        return (
-            repo_id == pantsbuild_pants_travis_repo_id
-            and created_at >= date_mechanism_first_enabled
-        )

--- a/src/server.py
+++ b/src/server.py
@@ -36,8 +36,6 @@ def index() -> str:
 @app.route("/token/generate", methods=["POST"])
 def generate_token() -> str:
     travis_job = TravisJob.get_from_api(job_id=int(flask.request.get_json()["travis_job_id"]))
-    if travis_job is None:
-        flask.abort(500)
     if not travis_job.is_valid():
         flask.abort(404)
     return str(travis_job)

--- a/src/travis.py
+++ b/src/travis.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+import requests
+
+DATE_MECHANISM_FIRST_ENABLED = datetime(year=2019, month=7, day=11)
+PANTSBUILD_PANTS_REPO_ID = 402860
+
+JobId = int
+
+
+@dataclass(frozen=True)
+class TravisJob:
+    id_: JobId
+    repo_id: int
+    created_at: datetime
+
+    @classmethod
+    def get_from_api(cls, job_id: JobId) -> Optional[TravisJob]:
+        travis_token = get_travis_token()
+        if travis_token is None:
+            return None
+        travis_response = requests.get(
+            f"https://api.travis-ci.org/job/{job_id}",
+            headers={"Travis-API-Version": "3", "Authorization": f"token {travis_token}"},
+        )
+        data = travis_response.json()
+        try:
+            return TravisJob(
+                id_=job_id,
+                repo_id=data["repository"]["id"],
+                created_at=datetime.fromisoformat(data["created_at"][:-5]),
+            )
+        except KeyError:
+            return None
+
+    def is_valid(self) -> bool:
+        """Check that the job belongs to pantsbuild.pants and that it was created after we turned
+          on this mechanism."""
+        return (
+            self.repo_id == PANTSBUILD_PANTS_REPO_ID
+            and self.created_at >= DATE_MECHANISM_FIRST_ENABLED
+        )
+
+
+def get_travis_token() -> Optional[str]:
+    return os.getenv("TRAVIS_TOKEN")

--- a/src/travis.py
+++ b/src/travis.py
@@ -4,14 +4,38 @@ import os
 from base64 import b64decode
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional
 
 import requests
+from google.cloud import kms_v1
 
 DATE_MECHANISM_FIRST_ENABLED = datetime(year=2019, month=7, day=11)
 PANTSBUILD_PANTS_REPO_ID = 402860
 
 JobId = int
+
+
+def _get_travis_token() -> str:
+    env_var = "TRAVIS_TOKEN_ENCRYPTED"
+    if env_var not in os.environ:
+        raise OSError(
+            f"Missing value for `{env_var}`. When running via Google App Engine, this should be "
+            "automatically set from `app.yaml`. When running locally, you must set this to the "
+            "value in `app.yaml`."
+        )
+    kms_client = kms_v1.KeyManagementServiceClient()
+    resource_name = kms_client.crypto_key_path_path(
+        project="pants-remoting-beta",
+        location="global",
+        key_ring="rbe-token-server",
+        crypto_key_path="travis",
+    )
+    token: str = kms_client.decrypt(
+        name=resource_name, ciphertext=b64decode(os.environ[env_var])
+    ).plaintext.decode()
+    return token
+
+
+TRAVIS_TOKEN = _get_travis_token()
 
 
 @dataclass(frozen=True)
@@ -21,20 +45,19 @@ class TravisJob:
     created_at: datetime
 
     @classmethod
-    def get_from_api(cls, job_id: JobId) -> Optional[TravisJob]:
+    def get_from_api(cls, *, job_id: JobId) -> TravisJob:
         travis_response = requests.get(
             f"https://api.travis-ci.org/job/{job_id}",
-            headers={"Travis-API-Version": "3", "Authorization": f"token {_get_travis_token()}"},
+            headers={"Travis-API-Version": "3", "Authorization": f"token {TRAVIS_TOKEN}"},
         )
+        if not travis_response.ok:
+            travis_response.raise_for_status()
         data = travis_response.json()
-        try:
-            return TravisJob(
-                id_=job_id,
-                repo_id=data["repository"]["id"],
-                created_at=datetime.fromisoformat(data["created_at"][:-5]),
-            )
-        except KeyError:
-            return None
+        return TravisJob(
+            id_=job_id,
+            repo_id=data["repository"]["id"],
+            created_at=datetime.fromisoformat(data["created_at"][:-5]),
+        )
 
     def is_valid(self) -> bool:
         """Check that the job belongs to pantsbuild.pants and that it was created after we turned
@@ -43,17 +66,3 @@ class TravisJob:
             self.repo_id == PANTSBUILD_PANTS_REPO_ID
             and self.created_at >= DATE_MECHANISM_FIRST_ENABLED
         )
-
-
-def _get_travis_token() -> str:
-    local_env_var = "TRAVIS_TOKEN"
-    gae_env_var = "TRAVIS_TOKEN_ENCRYPTED"
-    if gae_env_var not in os.environ and local_env_var not in os.environ:
-        raise OSError(
-            f"If running locally, you must set the env var `{local_env_var}` with your token "
-            "generated via `travis token`. If running via Google App Engine, the env var "
-            f"`{gae_env_var}` is not being properly picked up."
-        )
-    if gae_env_var in os.environ:
-        return b64decode(os.environ[gae_env_var]).decode()
-    return os.environ[local_env_var]


### PR DESCRIPTION
Google App Engine does not have a defined mechanism to securely set environment variables in the deployment environment, as it only allows installing raw env vars in `app.yaml`.

Per the recommendation from https://stackoverflow.com/a/56107715, we safely workaround this by using Google Cloud KMS. We created a key in the Google Cloud console that was then used to run `gcloud kms encrypt` against the `travis token` from the account `pantsbuild-ci-bot`. Then, the server uses the KMS client library to decrypt this token and authenticate against Travis.

We must use base64 encryption on the already encrypted Travis token to make the value ASCII, so that we can put it safely in `app.yaml`.