### PR TITLE
Stop caring what specific shard the request comes from

### DIFF
--- a/src/travis.py
+++ b/src/travis.py
@@ -4,7 +4,6 @@ import os
 from base64 import b64decode
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from enum import Enum
 
 import requests
 from google.cloud import kms_v1
@@ -13,15 +12,6 @@ DATE_MECHANISM_FIRST_ENABLED = datetime(year=2019, month=7, day=15, tzinfo=timez
 PANTSBUILD_PANTS_REPO_ID = 402860
 
 JobId = int
-
-
-class Stage(Enum):
-    daily = "Test Pants"
-    cron = "Test Pants (Cron)"
-
-    def valid_shard_number(self, shard_number: int) -> bool:
-        valid_shards = [3, 5, 6] if self == Stage.daily else [5, 7, 8]
-        return shard_number in valid_shards
 
 
 def _get_travis_token() -> str:
@@ -55,7 +45,6 @@ class TravisJob:
     created_at: datetime
     started_at: datetime
     shard_number: int
-    stage: Stage
 
     @classmethod
     def get_from_api(cls, *, job_id: JobId) -> TravisJob:
@@ -78,12 +67,10 @@ class TravisJob:
             created_at=parse_datetime(data["created_at"], includes_milliseconds=True),
             started_at=parse_datetime(data["started_at"], includes_milliseconds=False),
             shard_number=int(data["number"].split(".")[1]),
-            stage=Stage(data["stage"]["name"]),
         )
 
     def is_valid(self) -> bool:
         return (
             self.repo_id == PANTSBUILD_PANTS_REPO_ID
             and self.created_at >= DATE_MECHANISM_FIRST_ENABLED
-            and self.stage.valid_shard_number(self.shard_number)
         )


### PR DESCRIPTION
We want to start remoting the lint shard now that we have V2 isort. To do this, we simply stop caring what the shard number is and allow any shard from an authenticated build to generate a token. 

This is slightly less secure, but not by enough to matter. Someone could just as easily grab a token through the authorized shards. 

The benefit of this change is that we decouple this repository from any changes to Pants CI remote execution.